### PR TITLE
Added TabClosed callback & custom control type

### DIFF
--- a/nativeSettings/init.lua
+++ b/nativeSettings/init.lua
@@ -1,6 +1,6 @@
 local nativeSettings = {
     data = {},
-	currentData = -1,
+	currenTabPath = nil,
     fromMods = false,
     minCETVersion = 1.180000,
     settingsMainController = nil,
@@ -73,6 +73,7 @@ registerForEvent("onInit", function()
     Observe("SettingsMainGameController", "RequestClose", function () -- Handle mod settings close
         if not nativeSettings.fromMods then return end
 		nativeSettings.callCurrentTabClosedCallback()
+		nativeSettings.currenTabPath = nil
         nativeSettings.fromMods = false
         nativeSettings.settingsMainController = nil
         nativeSettings.clearControllers()
@@ -166,9 +167,9 @@ registerForEvent("onInit", function()
                     idx = this.selectorCtrl:GetToggledIndex()
                 end
 
-				nativeSettings.closedCallback = idx + 1
+                local settingsCategory = this.data[idx + 1]
 
-                local settingsCategory = this.data[nativeSettings.currentData]
+				nativeSettings.currenTabPath = string.sub( NameToString(settingsCategory.groupPath), 2 ) -- Remove leading slash
 
                 nativeSettings.Cron.NextTick(function() -- "reduce the number of calls to game functions inside that single override" ~ psiberx
                     nativeSettings.clearControllers()
@@ -1094,10 +1095,11 @@ function nativeSettings.restoreScrollPos()
 end
 
 function nativeSettings.callCurrentTabClosedCallback()
-	if nativeSettings.currentData >= 0 then
-		local currtab =  nativeSettings.data[ nativeSettings.currentData ]
-		if currtab and currtab.closedCallback then
-			currtab.closedCallback()
+	if nativeSettings.currenTabPath then
+		local tab = nativeSettings.data[  nativeSettings.currenTabPath ]
+
+		if tab then
+			tab.closedCallback()
 		end
 	end
 end

--- a/nativeSettings/init.lua
+++ b/nativeSettings/init.lua
@@ -1095,13 +1095,13 @@ function nativeSettings.restoreScrollPos()
 end
 
 function nativeSettings.callCurrentTabClosedCallback()
-	if nativeSettings.currenTabPath then
-		local tab = nativeSettings.data[  nativeSettings.currenTabPath ]
+    if nativeSettings.currenTabPath then
+        local tab = nativeSettings.data[  nativeSettings.currenTabPath ]
 
-		if tab then
-			tab.closedCallback()
-		end
-	end
+        if tab and tab.closedCallback then
+            tab.closedCallback()
+        end
+    end
 end
 
 return nativeSettings

--- a/nativeSettings/init.lua
+++ b/nativeSettings/init.lua
@@ -698,6 +698,29 @@ function nativeSettings.addKeyBinding(path, label, desc, value, defaultValue, ca
     return keyBinding
 end
 
+function nativeSettings.addCustom(path, callback, optionalIndex) -- Call this to add a button widget
+    local validPath, state, tabPath, subPath = nativeSettings.pathExists(path)
+
+    if not validPath then
+        print("[NativeSettings] Path provided to the custom control is not valid!")
+        return
+    end
+
+    local custom = {type = "custom", path = path, callback = callback, controller = nil, fullPath = path}
+
+    if state == 0 then -- Add to subcategory
+        custom.path = subPath
+        local idx = optionalIndex or #nativeSettings.data[tabPath].subcategories[subPath].options + 1
+        table.insert(nativeSettings.data[tabPath].subcategories[subPath].options, idx, custom)
+    else -- Add to main tab
+        custom.path = tabPath
+        local idx = optionalIndex or #nativeSettings.data[tabPath].options + 1
+        table.insert(nativeSettings.data[tabPath].options, idx, custom)
+    end
+
+    return custom
+end
+
 function nativeSettings.pathExists(path) -- Check if a path exists, return a boolean (Other returns can be ignored). Useful if you want to have two independet mods adding their options to the same tab
     if path:match("/.*/.*") then
         local tabPath = path:match("/.*/"):gsub("/", "")
@@ -821,6 +844,8 @@ function nativeSettings.populateOptions(this, categoryPath, subCategoryPath) -- 
                 nativeSettings.spawnButton(this, option)
             elseif option.type == "keyBinding" then
                 nativeSettings.spawnKeyBinding(this, option)
+			elseif option.type == "custom" then
+				option.callback(this.settingsOptionsList.widget, option)
             end
         end
     else
@@ -838,6 +863,8 @@ function nativeSettings.populateOptions(this, categoryPath, subCategoryPath) -- 
                 nativeSettings.spawnButton(this, option)
             elseif option.type == "keyBinding" then
                 nativeSettings.spawnKeyBinding(this, option)
+			elseif option.type == "custom" then
+				option.callback(this.settingsOptionsList.widget, option)
             end
         end
     end


### PR DESCRIPTION
Hello, thank you for your feedback last time. So I cleaned up the code and made it more general, instead of loading and saving.

When the tab is changed, or the mod settings menu is closed, there is now a tabClosed callback that is called. Allowing you to remove any additional UI and to save your settings.

I also added a "custom" UI type. It basically a callback which is called, when the UI element is created. This allows you to add any UI element to your settings screen, that is too special to be a general settings UI. I use it to add the preview text for my Furigana mod. This way you can add custom UI elements, without breakiing compatibility with the installed mod version.
https://www.nexusmods.com/cyberpunk2077/mods/3775?tab=images

It would be great if you would consider my changes, since I currently have to tell people to install a custom version of this mod in order to use mine.

Thank you,
Daniel