### PR TITLE
Add option to add restore defaults callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ A small mod for Cyberpunk 2077 that allows other mods to easily add settings opt
 	-- Parameters: path
 	nativeSettings.removeSubcategory("/myMod/sub")
 	```
+
+## Custom Restore Defaults:
+- A custom callback function can be registered for a tab, and optionally the normal restore default actions can be overridden
+	```lua
+	-- Parameters: path, overrideNativeRestoreDefaults, callback
+
+	nativeSettings.registerRestoreDefaultsCallback("/myMod", true, function()
+		-- Handle restoring defaults with your own logic
+	end)
+	```
 	
 ## The `refresh` function:
 - Calling this function is not necessary anymore, as of version 1.4

--- a/nativeSettings/init.lua
+++ b/nativeSettings/init.lua
@@ -524,6 +524,14 @@ registerForEvent("onInit", function()
                 tabIndex = tabIndex + #nativeSettings.tabSizeCache[i]
             end
 
+            if nativeSettings.data[nativeSettings.currentTabPath].restoreDefaultsCallback ~= nil then
+                nativeSettings.data[nativeSettings.currentTabPath].restoreDefaultsCallback()
+            end
+
+            if nativeSettings.data[nativeSettings.currentTabPath].overrideNativeRestoreDefaults then
+                return
+            end
+
             local settingsCategory = (this.data[tabIndex].groupPath.value):gsub("/", "")
 
             for _, o in pairs(nativeSettings.data[settingsCategory].options) do
@@ -990,6 +998,13 @@ function nativeSettings.setOption(tab, value) -- Use this to set an options valu
     end
 
     if not success then print(string.format("[NativeSettings] Could not set the option for \"%s\" correctly, the provided options table could not be found!", tab.label)) end
+end
+
+function nativeSettings.registerRestoreDefaultsCallback(path, overrideNativeRestoreDefaults, callback) -- Use this to have your function called when the user restores defaults. If overrideNativeRestoreDefaults is false then Native Settings will restore defaults as normal after the callback is called.
+    path = path:gsub("/", "")
+
+    nativeSettings.data[path].overrideNativeRestoreDefaults = overrideNativeRestoreDefaults
+    nativeSettings.data[path].restoreDefaultsCallback = callback
 end
 
 function nativeSettings.refresh() -- Refreshes the UI, e.g. after adding / removing widgets. Not needed anymore as of version 1.4


### PR DESCRIPTION
The current restore defaults functionality only changes the settings options currently on screen / existing in Native Settings, but some mods dynamically change which settings are visible based on other options, so currently hidden (non-existent) settings won't be updated with defaults.

This PR adds a function with a callback parameter that is called when the restore defaults button is pressed. The normal restore defaults action on the existing settings can optionally be turned off/overridden. If those are not overridden, the callback is called before the options are set to default values.