### PR TITLE
Pagination/tab fixes

### DIFF
--- a/nativeSettings/init.lua
+++ b/nativeSettings/init.lua
@@ -237,14 +237,21 @@ registerForEvent("onInit", function()
         end
     end)
 
-    ObserveBefore("SettingsMainGameController", "OnButtonRelease", function (this, event) -- Enable page scrolling via next / previous tab buttons
+    Override("SettingsMainGameController", "OnButtonRelease", function (this, event, wrapped) -- Enable page scrolling via next / previous tab buttons
         local currentToggledIndex = this.selectorCtrl:GetToggledIndex()
         if event:IsAction("prior_menu") and currentToggledIndex < 1 then
+            if nativeSettings.currentPage == 1 then
+                return
+            end
             nativeSettings.switchToPreviousPage(this, true)
         elseif event:IsAction("next_menu") and currentToggledIndex >= this.selectorCtrl:Size() - 1 then
+            if nativeSettings.tabSizeCache and nativeSettings.currentPage == #nativeSettings.tabSizeCache then
+                return
+            end
             nativeSettings.switchToNextPage(this, true)
             this.selectorCtrl:SetToggledIndex(-1) -- Avoid skipping the first tab
         end
+        wrapped(event)
     end)
 
     -- Adding UI things:

--- a/nativeSettings/init.lua
+++ b/nativeSettings/init.lua
@@ -12,6 +12,7 @@ local nativeSettings = {
     tabSizeCache = nil,
     currentPage = 1,
     switchPage = false,
+    nextPageFirstTabLoad = false,
     previousButton = nil,
     nextButton = nil,
     version = 1.95,
@@ -262,6 +263,11 @@ registerForEvent("onInit", function()
 
     Override("SettingsMainGameController", "PopulateCategorySettingsOptions", function (this, idx, wrapped) -- Add actual settings options
         if nativeSettings.fromMods and nativeSettings.tabSizeCache then -- Dont spawn options for the tab size cache phase, to avoid ghost options
+            if nativeSettings.nextPageFirstTabLoad then
+                nativeSettings.nextPageFirstTabLoad = false
+                return
+            end
+            
             this:PopulateSettingsData()
             nativeSettings.saveScrollPos()
             nativeSettings.callCurrentTabClosedCallback()
@@ -1363,6 +1369,7 @@ function nativeSettings.switchToNextPage(settingsController)
         nativeSettings.previousButton.root:SetVisible(true)
     end
 
+    nativeSettings.nextPageFirstTabLoad = true
     settingsController:PopulateCategories(settingsController.settings:GetMenuIndex())
 end
 

--- a/nativeSettings/init.lua
+++ b/nativeSettings/init.lua
@@ -240,12 +240,12 @@ registerForEvent("onInit", function()
     Override("SettingsMainGameController", "OnButtonRelease", function (this, event, wrapped) -- Enable page scrolling via next / previous tab buttons
         local currentToggledIndex = this.selectorCtrl:GetToggledIndex()
         if event:IsAction("prior_menu") and currentToggledIndex < 1 then
-            if nativeSettings.currentPage == 1 then
+            if nativeSettings.currentPage == 1 and nativeSettings.tabSizeCache and #nativeSettings.tabSizeCache > 1 then
                 return
             end
             nativeSettings.switchToPreviousPage(this, true)
         elseif event:IsAction("next_menu") and currentToggledIndex >= this.selectorCtrl:Size() - 1 then
-            if nativeSettings.tabSizeCache and nativeSettings.currentPage == #nativeSettings.tabSizeCache then
+            if nativeSettings.tabSizeCache and nativeSettings.currentPage == #nativeSettings.tabSizeCache and #nativeSettings.tabSizeCache > 1 then
                 return
             end
             nativeSettings.switchToNextPage(this, true)

--- a/nativeSettings/init.lua
+++ b/nativeSettings/init.lua
@@ -39,10 +39,14 @@ registerForEvent("onInit", function()
         local rootWidget = this:GetRootCompoundWidget()
 
         local button = rootWidget:GetWidgetByPath(BuildWidgetPath({ "wrapper", "extra", "brightness_btn"}))
-        button:SetMargin(5000, 5000, 5000, 5000)
-
+        if button then
+            button:SetMargin(5000, 5000, 5000, 5000)
+        end
+        
         local button = rootWidget:GetWidgetByPath(BuildWidgetPath({ "wrapper", "extra", "hdr_btn"}))
-        button:SetMargin(5000, 5000, 5000, 5000)
+        if button then
+            button:SetMargin(5000, 5000, 5000, 5000)
+        end
     end)
 
     ObserveAfter("SettingsMainGameController", "OnInitialize", function (this) -- Get a ref to the settingsOptionsList
@@ -1346,6 +1350,7 @@ function nativeSettings.callCurrentTabClosedCallback()
 end
 
 function nativeSettings.switchToNextPage(settingsController)
+    if not nativeSettings.tabSizeCache or not nativeSettings.nextButton then return end
     nativeSettings.currentPage = nativeSettings.currentPage + 1
     nativeSettings.currentPage = math.min(#nativeSettings.tabSizeCache, nativeSettings.currentPage)
     nativeSettings.switchPage = true
@@ -1362,6 +1367,7 @@ function nativeSettings.switchToNextPage(settingsController)
 end
 
 function nativeSettings.switchToPreviousPage(settingsController)
+    if not nativeSettings.previousButton then return end
     nativeSettings.currentPage = nativeSettings.currentPage - 1
     nativeSettings.currentPage = math.max(1, nativeSettings.currentPage)
     nativeSettings.switchPage = true


### PR DESCRIPTION
A few fixes mostly for issues with wrong/empty settings after switching pages. Hopefully the correct page displays in all cases now,  e.g. with different ways to switch tabs, page switching, and when going back and forth to base settings menu and mod settings menu.

- Fix: double options after switching to the next page (https://github.com/justarandomguyintheinternet/CP77_nativeSettings/issues/5)
- Fix: wrong option page displayed after switching to previous page
- Preference/Fix: If there's more than one page, pressing 1/3 will not do anything if you're at the end of the first or last page. 

Alternative for the last one would be to have those buttons wrap you around between the left most tab on first page and the last tab on the last page. I think that would be better, but is more work to implement. I don't think it should wrap the way it does now with multiple pages. Feel free to cherry pick or let me know and I can take that change out.